### PR TITLE
Account Page Sidebar

### DIFF
--- a/apps/frontend/tests/component_tests/Account.cy.tsx
+++ b/apps/frontend/tests/component_tests/Account.cy.tsx
@@ -1,0 +1,36 @@
+import { BrowserRouter } from "react-router-dom";
+import Account from "../../src/pages/Account";
+
+describe("<Account />", () => {
+  beforeEach(() => {
+    cy.mount(
+      <BrowserRouter>
+        <Account />
+      </BrowserRouter>
+    );
+  });
+
+  it("renders the Account page", () => {
+    cy.get("h4").contains("Account");
+
+    // Check if the page contains the necessary components
+    cy.get("h5").contains("Your Profile");
+    cy.get("h5").contains("Your Listings");
+    cy.get("h5").contains("Your Reviews");
+  });
+
+  it("navigates to the Your Profile page", () => {
+    cy.get("h5").contains("Your Profile").click();
+    cy.get("h1").contains("YourProfile");
+  });
+
+  it("navigates to the Your Listings page", () => {
+    cy.get("h5").contains("Your Listings").click();
+    cy.get("h1").contains("YourListings");
+  });
+
+  it("navigates to the Your Reviews page", () => {
+    cy.get("h5").contains("Your Reviews").click();
+    cy.get("h1").contains("YourReviews");
+  });
+});


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change(s) and which issue is being fixed. Please provide as much detail as possible. -->
Created `Account` page side panel that allows user to navigate to their profile page, view their listings, and see listings they have reviewed. By default, when the user first arrives on the `Account` page they will land on their `Profile` page.

<img width="1269" alt="Screenshot 2024-06-11 at 8 56 55 AM" src="https://github.com/UVicMartletplace/martletplace/assets/72957712/023d14f6-a437-424b-8a2a-f757aa66a920">

<!-- Replace `XXX` with the concerning issue number. The "#" links this PR to its relevant issue -->
Closes #61 

## How to Test
<!-- Provide some simple steps so that others can verify your implementation -->
- [ ] Run MartletPlace locally
- [ ] Navigate to url: http://localhost:8101/user
- [ ] Try clicking on the different options ion the side to ensure you can see the Your Profile, Your Listings, and Your Reviews, components

## Checklist
- [ ] The code includes tests if relevant
- [ ] I have *actually* self-reviewed my changes and done QA
<!-- Only check this off if you have actually done a self-review! DO NOT request any review from others until you have done your self-review! -->
