### PR TITLE
Service networks added to datalayer networks list

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
       - POSTGRESQL_HOST=database
       - POSTGRESQL_PORT=8310
     ports: [ 8300:8300, 8301:8301 ]
-    networks: [ datalayer-database, datalayer-elasticsearch, datalayer-cache, datalayer-blob ]
+    networks: [ datalayer-database, datalayer-elasticsearch, datalayer-cache, datalayer-blob, user-datalayer, listing-datalayer, review-datalayer, message-datalayer, search-datalayer, recommend-datalayer ]
 
   database:
     build: apps/data/database


### PR DESCRIPTION
# Description
Adds service networks to datalayer networks list to restore communication. This should fix issues preventing endpoints from connecting to the datalayer/database.


<!-- Replace `XXX` with the concerning issue number. The "#" links this PR to its relevant issue -->
Closes #186 


