### PR TITLE
arun/christian/57-recommender-api-endpoint-fixes

### DIFF
--- a/apps/algorithm/recommend/src/api_models.py
+++ b/apps/algorithm/recommend/src/api_models.py
@@ -4,13 +4,14 @@ from datetime import datetime, timezone
 
 
 class ListingSummary(BaseModel):
-    listing_id: Optional[int] = Field(
+    listingID: Optional[int] = Field(
         default=None, description="The primary key for the listing."
     )
-    seller_id: int = Field(
+    sellerID: int = Field(
         ..., description="The ID of the seller, foreign key to users."
     )
-    buyer_id: Optional[int] = Field(
+    sellerName: str = Field(..., description="The name of the seller.")
+    buyerID: Optional[int] = Field(
         default=None, description="The ID of the buyer, if any."
     )
     title: str = Field(..., description="The title of the listing.")
@@ -22,10 +23,11 @@ class ListingSummary(BaseModel):
     description: Optional[str] = Field(
         default=None, description="A detailed description of the listing."
     )
-    image_urls: List[str] = Field(
-        default=[], description="A list of URLs for images associated with the listing."
+    imageUrl: str = Field(
+        default=...,
+        description="The URL for the first image associated with the listing.",
     )
-    created_at: datetime = Field(
+    dateCreated: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
         description="The UTC timestamp when the listing was created.",
     )

--- a/apps/algorithm/recommend/src/api_models.py
+++ b/apps/algorithm/recommend/src/api_models.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import Optional, List
+from typing import Optional
 from datetime import datetime, timezone
 
 

--- a/apps/algorithm/recommend/src/server.py
+++ b/apps/algorithm/recommend/src/server.py
@@ -83,16 +83,18 @@ async def get_recommendations(
         else:
             loc = {"latitude": 0, "longitude": 0}
         listing_summary = ListingSummary(
-            listing_id=row["listing_id"],
-            seller_id=row["seller_id"],
-            buyer_id=row["buyer_id"],
+            listingID=row["listing_id"],
+            sellerID=row["seller_id"],
+            # Will query for actual seller name later.
+            sellerName="Seller",
+            buyerID=row["buyer_id"],
             title=str(row["title"]),
             price=row["price"],
             location=loc,
             status=str(row["status"]),
             description=str(row["description"]),
-            image_urls=img_urls,
-            created_at=row["created_at"],
+            imageUrl=str(img_urls[0]),
+            dateCreated=row["created_at"],
             modified_at=row["modified_at"],
         )
         listing_summaries.append(listing_summary)


### PR DESCRIPTION
# Description
The recommender output for /api/get/recommendations does not follow the API spec outlined in the shared API agreement. The names of fields use snake_case, as opposed to camelCase, and some fields have different names (dateCreated vs created_at). 

This must be corrected for the front end to access the recommenders's ListingSummary fields correctly.


<!-- Replace `XXX` with the concerning issue number. The "#" links this PR to its relevant issue -->
Closes #57 

## How to Test
Go to the frontend view for recommendations and verify that all the fields appear, such as the image, seller name, title, price, and date created.


## Checklist
- [x] The code includes tests if relevant
- [x] I have *actually* self-reviewed my changes and done QA
<!-- Only check this off if you have actually done a self-review! DO NOT request any review from others until you have done your self-review! -->
