### PR TITLE
Set authorization = 5 as default value if authorization is not provided.

### DIFF
--- a/apps/algorithm/recommend/src/server.py
+++ b/apps/algorithm/recommend/src/server.py
@@ -18,7 +18,7 @@ recommender = Recommender()
 
 @app.get("/api/recommendations", response_model=List[ListingSummary])
 async def get_recommendations(
-    authorization: str,
+    authorization: str = "5",
     page: int = 1,
     limit: int = 20,
     session: AsyncSession = Depends(get_session),


### PR DESCRIPTION
# Description
Set authorization =5 as the default value for authorization if no value is specified for the recommender demo to work.

