### PR TITLE
[Frontend] Fix Axios being hardcoded to `localhost`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,17 @@
 # Clone the repository
 git clone https://github.com/UVicMartletplace/martletplace && cd martletplace
 
-# To start developing, run the docker compose stack
-docker compose up --build
+# Run the docker compose stack with hot reloading
+docker compose up --build -d
+
+# View all container logs
+docker compose logs -f
+
+# When you want to shut it down
+docker compose down -v
 ```
 
-The development environment is now running and accessible at [http://local.martletplace.ca/](http://local.martletplace.ca/)
+The development environment is now running (give it ~1min to spin up) and accessible at [http://local.martletplace.ca/](http://local.martletplace.ca/)
 
 ### Testing
 

--- a/apps/frontend/src/_axios_instance.tsx
+++ b/apps/frontend/src/_axios_instance.tsx
@@ -2,7 +2,7 @@ import axios from "axios";
 
 // Create an instance of axios with custom default configurations
 const _axios_instance = axios.create({
-  baseURL: "http://localhost/api/", // Your custom base URL
+  baseURL: `${window.location.protocol}//${window.location.hostname}/api/`,
   timeout: 40000, // Optional: Set a timeout for requests in milliseconds
 });
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change(s) and which issue is being fixed. Please provide as much detail as possible. -->
Replace the hardcoded `localhost` with the proper `window.location` APIs

<!-- Replace `XXX` with the concerning issue number. The \"#\" links this PR to its relevant issue -->
Closes #293

## How to Test
<!-- Provide some simple steps so that others can verify your implementation -->
Access the frontend from both `localhost` and `local.martletplace.ca` and ensure the api calls don't get blocked by CORS

## Checklist
- [x] The code includes tests if relevant
- [x] I have *actually* self-reviewed my changes and done QA
<!-- Only check this off if you have actually done a self-review! DO NOT request any review from others until you have done your self-review! -->