### PR TITLE
Fix pgsync-search race condition

### DIFF
--- a/apps/algorithm/search/src/routes.py
+++ b/apps/algorithm/search/src/routes.py
@@ -13,18 +13,6 @@ search_router = APIRouter()
 
 es = Elasticsearch([ES_ENDPOINT], verify_certs=False)
 
-if not es.indices.exists(index=DEFAULT_INDEX):
-    es.indices.create(
-        index=DEFAULT_INDEX,
-        body={
-            "mappings": {
-                "properties": {
-                    "location": {"type": "geo_point"},
-                }
-            }
-        },
-    )
-
 
 @search_router.get("/api/search")
 async def search(


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change(s) and which issue is being fixed. Please provide as much detail as possible. -->
Fixes a race condition where pgsync and the search service both attempt to create the `martletplace` elasticsearch index, which causes pgsync to crash if it loses the race

<!-- Replace `XXX` with the concerning issue number. The "#" links this PR to its relevant issue -->
Closes #321 

## How to Test
<!-- Provide some simple steps so that others can verify your implementation -->
`docker compose up --build`

## Checklist
- [x] The code includes tests if relevant
- [x] I have *actually* self-reviewed my changes and done QA
<!-- Only check this off if you have actually done a self-review! DO NOT request any review from others until you have done your self-review! -->
