### PR TITLE
[O11Y] Add advanced DB instrumentation to backend services

### DIFF
--- a/apps/backend/lib/src/otel.ts
+++ b/apps/backend/lib/src/otel.ts
@@ -55,20 +55,20 @@ export const setupTracing = (serviceName: string) => {
  */
 export function connectDB(connection_string: string) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  function genericDbQuery(old_fn: any) {
+  function genericDbQuery(oldFn: any) {
     const serviceName = SERVICENAME;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return async function(...args: any[]) {
+    return async function (...args: any[]) {
       if (args.length > 0) {
         const t = trace.getTracer(serviceName);
         const s = t.startSpan("pg.query");
         s.setAttribute("db.statement", args[0].toString());
-        const out = await old_fn(...args);
+        const out = await oldFn(...args);
         s.end();
         return Promise.resolve(out);
       } else {
-        return old_fn(...args);
+        return oldFn(...args);
       }
     };
   }

--- a/apps/backend/lib/src/otel.ts
+++ b/apps/backend/lib/src/otel.ts
@@ -14,6 +14,7 @@ import {
 } from "@opentelemetry/sdk-trace-node";
 import { ExpressInstrumentation } from "@opentelemetry/instrumentation-express";
 import { HttpInstrumentation } from "@opentelemetry/instrumentation-http";
+import pgPromise from "pg-promise";
 
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.WARN);
 
@@ -22,8 +23,10 @@ if (!OTEL_COLLECTOR_ENDPOINT) {
   console.error("OTEL_COLLECTOR_ENDPOINT environment variable is not set");
   process.exit(1);
 }
+let SERVICENAME: string;
 
 export const setupTracing = (serviceName: string) => {
+  SERVICENAME = serviceName;
   const provider = new NodeTracerProvider({
     resource: new Resource({
       [SEMRESATTRS_SERVICE_NAME]: serviceName,
@@ -44,3 +47,54 @@ export const setupTracing = (serviceName: string) => {
 
   return trace.getTracer(serviceName);
 };
+
+/*
+ * The OTEL library @opentelemetry/instrumentation-pg logs all sql queries in full
+ * (including the parameterized values). This leaks information and is bad. So instead
+ * I had to write this crime against humanity.
+ */
+export function connectDB(connection_string: string) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function genericDbQuery(old_fn: any) {
+    const serviceName = SERVICENAME;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return async function(...args: any[]) {
+      if (args.length > 0) {
+        const t = trace.getTracer(serviceName);
+        const s = t.startSpan("pg.query");
+        s.setAttribute("db.statement", args[0].toString());
+        const out = await old_fn(...args);
+        s.end();
+        return Promise.resolve(out);
+      } else {
+        return old_fn(...args);
+      }
+    };
+  }
+
+  const db = pgPromise()(connection_string);
+
+  const oldNone = db.none;
+  db.none = genericDbQuery(oldNone);
+
+  const oldOneOrNone = db.oneOrNone;
+  db.oneOrNone = genericDbQuery(oldOneOrNone);
+
+  const oldOne = db.one;
+  db.one = genericDbQuery(oldOne);
+
+  const oldAny = db.any;
+  db.any = genericDbQuery(oldAny);
+
+  const oldMany = db.many;
+  db.many = genericDbQuery(oldMany);
+
+  const oldManyOrNone = db.manyOrNone;
+  db.manyOrNone = genericDbQuery(oldManyOrNone);
+
+  const oldResult = db.result;
+  db.result = genericDbQuery(oldResult);
+
+  return db;
+}

--- a/apps/backend/listing/src/index.ts
+++ b/apps/backend/listing/src/index.ts
@@ -1,9 +1,8 @@
-import { setupTracing } from "../../lib/src/otel";
+import { connectDB, setupTracing } from "../../lib/src/otel";
 setupTracing("listing");
 
 import express, { Request, Response, NextFunction } from "express";
 import morgan from "morgan";
-import pgPromise from "pg-promise";
 import { getListingById } from "./getListingById";
 import { getListingsByUser } from "./getListingsByUser";
 import { createListing } from "./createListing";
@@ -21,7 +20,6 @@ app.use(express.json());
 app.use(cookieParser());
 app.use(authenticate_request);
 
-const pgp = pgPromise();
 const DB_ENDPOINT = process.env.DB_ENDPOINT;
 
 if (!DB_ENDPOINT) {
@@ -29,7 +27,7 @@ if (!DB_ENDPOINT) {
   process.exit(1);
 }
 
-const db = pgp(DB_ENDPOINT);
+const db = connectDB(DB_ENDPOINT);
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 app.use((err: Error, req: Request, res: Response, next: NextFunction) => {

--- a/apps/backend/message/src/index.ts
+++ b/apps/backend/message/src/index.ts
@@ -1,11 +1,10 @@
-import { setupTracing } from "../../lib/src/otel";
+import { connectDB, setupTracing } from "../../lib/src/otel";
 setupTracing("message");
 
 import express, { Request, Response, NextFunction } from "express";
 import morgan from "morgan";
 import cookieParser from "cookie-parser";
 import { authenticate_request, AuthenticatedRequest } from "../../lib/src/auth";
-import pgPromise from "pg-promise";
 import { getMessageThreads } from "./getMessageThreads";
 import { getMessages, useValidateGetMessages } from "./getMessages";
 import { createMessage, useValidateCreateMessage } from "./createMessage";
@@ -19,13 +18,12 @@ app.use(express.json());
 app.use(cookieParser());
 app.use(authenticate_request);
 
-const pgp = pgPromise();
 const DB_ENDPOINT = process.env.DB_ENDPOINT;
 if (!DB_ENDPOINT) {
   throw new Error("DB_ENDPOINT is not set");
 }
 
-const db = pgp(DB_ENDPOINT);
+const db = connectDB(DB_ENDPOINT);
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 app.use((err: Error, req: Request, res: Response, next: NextFunction) => {

--- a/apps/backend/review/src/index.ts
+++ b/apps/backend/review/src/index.ts
@@ -1,9 +1,8 @@
-import { setupTracing } from "../../lib/src/otel";
+import { connectDB, setupTracing } from "../../lib/src/otel";
 setupTracing("review");
 
 import express, { Request, Response, NextFunction } from "express";
 import morgan from "morgan";
-import pgPromise from "pg-promise";
 import { getReview } from "./getReview";
 import { createReview } from "./createReview";
 import { updateReview } from "./updateReview";
@@ -19,7 +18,6 @@ app.use(express.json());
 app.use(cookieParser());
 app.use(authenticate_request);
 
-const pgp = pgPromise();
 const DB_ENDPOINT = process.env.DB_ENDPOINT;
 
 if (!DB_ENDPOINT) {
@@ -27,7 +25,7 @@ if (!DB_ENDPOINT) {
   process.exit(1);
 }
 
-const db = pgp(DB_ENDPOINT);
+const db = connectDB(DB_ENDPOINT);
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 app.use((err: Error, req: Request, res: Response, next: NextFunction) => {

--- a/apps/backend/user/src/index.ts
+++ b/apps/backend/user/src/index.ts
@@ -1,9 +1,8 @@
-import { setupTracing } from "../../lib/src/otel";
+import { setupTracing, connectDB } from "../../lib/src/otel";
 setupTracing("user");
 
 import express, { Request, Response, NextFunction } from "express";
 import morgan from "morgan";
-import pgPromise from "pg-promise";
 import { createUser } from "./createUser";
 import { getUser } from "./getUser";
 import { patchUser } from "./patchUser";
@@ -18,7 +17,6 @@ import cookieParser from "cookie-parser";
 const PORT = 8211;
 
 const app = express();
-const pgp = pgPromise();
 const DB_ENDPOINT = process.env.DB_ENDPOINT;
 
 if (!DB_ENDPOINT) {
@@ -26,7 +24,7 @@ if (!DB_ENDPOINT) {
   process.exit(1);
 }
 
-const db = pgp(DB_ENDPOINT);
+const db = connectDB(DB_ENDPOINT);
 
 app.use(morgan("dev"));
 app.use(express.json());


### PR DESCRIPTION
# Description
Adds the `db.statement` span data so that we can observe database call timing

Closes #365

## Checklist
- [ ] The code includes tests if relevant
- [x] I have *actually* self-reviewed my changes and done QA
