### PR TITLE
[O11Y] Fix `/admin/tracing` path for Jaeger

### DIFF
--- a/apps/proxy/dynamic_config.yml
+++ b/apps/proxy/dynamic_config.yml
@@ -34,18 +34,17 @@ http:
       service: image
       priority: 200
     to-jaeger:
-      rule: "PathPrefix(`/jaeger`)"
+      rule: "PathPrefix(`/admin/tracing`)"
       service: jaeger
       priority: 200
       middlewares:
-        - strip-prefix
+        - admin-auth
 
   middlewares:
-    strip-prefix:
-      stripPrefix:
-        prefixes:
-          - "/jaeger"
-
+    admin-auth:
+      basicAuth:
+        users:
+          - admin:$2y$05$hzvNivF.d58imqlAMKkG5.iT0OSI8KfPQnSGlH8gXMQ0d4KO62me6
 
   services:
     frontend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -226,5 +226,4 @@ services:
     restart: unless-stopped
     depends_on: []
     volumes: []
-    command: "--query.http-server.host-port 0.0.0.0:16686 --collector.otlp.enabled --collector.otlp.grpc.host-port 0.0.0.0:4317 --collector.otlp.http.host-port 0.0.0.0:4318"
-    ports: [16686:16686]
+    command: "--query.base-path /admin/tracing --query.http-server.host-port 0.0.0.0:16686 --collector.otlp.enabled --collector.otlp.grpc.host-port 0.0.0.0:4317 --collector.otlp.http.host-port 0.0.0.0:4318"


### PR DESCRIPTION
# Description
Closes #378

## How to Test
Go to http://local.martletplace.ca/admin/tracing and use `admin` and the default password

## Checklist
- [ ] The code includes tests if relevant
- [x] I have *actually* self-reviewed my changes and done QA
