### PR TITLE
Fix seller name being hardcoded (recommendations)

### DIFF
--- a/apps/algorithm/recommend/src/server.py
+++ b/apps/algorithm/recommend/src/server.py
@@ -157,9 +157,8 @@ async def get_recommendations(
     recommended_listings = pd.DataFrame(recommended_listings, columns=columns)
 
     seller_ids = recommended_listings["seller_id"].tolist()
-    seller_names_query = (
-            select(Users.user_id, Users.name)
-            .where(Users.user_id.in_(seller_ids))
+    seller_names_query = select(Users.user_id, Users.name).where(
+        Users.user_id.in_(seller_ids)
     )
 
     seller_names_result = await session.exec(seller_names_query)


### PR DESCRIPTION
# Description
The seller name returned for personalized recommendations is hardcoded to "Seller", and should be returning the actual seller's name for that listing.

Closes #395 

## How to Test
Log in to the app, and click or search for an item to personalize your recommendations.

Then navigate back to the home page (where recommendations are), and ensure that the seller names are different and unique.

## Checklist
- [ ] The code includes tests if relevant
- [ ] I have *actually* self-reviewed my changes and done QA
