### PR TITLE
[Search] Run SQL in background to 3x reponse time

### DIFF
--- a/apps/algorithm/search/src/routes.py
+++ b/apps/algorithm/search/src/routes.py
@@ -2,7 +2,7 @@ import os
 from typing import Dict, Any
 
 from elasticsearch import Elasticsearch, NotFoundError
-from fastapi import APIRouter, HTTPException, Request, Response
+from fastapi import APIRouter, HTTPException, Request, Response, BackgroundTasks
 
 from .config import DEFAULT_INDEX, ES_ENDPOINT
 from .database import insert_user_search
@@ -21,6 +21,7 @@ es = Elasticsearch([ES_ENDPOINT], verify_certs=False)
 @search_router.get("/api/search")
 async def search(
     request: Request,
+    background_tasks: BackgroundTasks,
     query: str,
     latitude: float,
     longitude: float,
@@ -122,12 +123,7 @@ async def search(
         for hit in response["hits"]["hits"]
     ]
 
-    try:
-        user_id = request.state.user
-        await insert_user_search(user_id, query)
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
-
+    background_tasks.add_task(insert_user_search, request.state.user, query)
     return {"items": results, "totalItems": total_items}
 
 


### PR DESCRIPTION
# Description
The SQL INSERT does not need to happen while the client is waiting. The query now executes in a [FastAPI background task](https://fastapi.tiangolo.com/tutorial/background-tasks/). Any errors resulting from the query will not cause the search to fail but is not concerning as missing the data for a single search history is outweighed by the performance gains.

closes: #422

## How to Test
| Before| After|
|---|---|
|![image](https://github.com/user-attachments/assets/b6a782ad-cd1f-4b60-93ed-21e530aadc42)|![image](https://github.com/user-attachments/assets/2c71ae91-234a-4df3-810d-dc9dcd667773)|

## Checklist
- [ ] The code includes tests if relevant
- [x] I have *actually* self-reviewed my changes and done QA