### PR TITLE
show charity image

### DIFF
--- a/apps/frontend/src/components/CurrentCharity.tsx
+++ b/apps/frontend/src/components/CurrentCharity.tsx
@@ -66,7 +66,7 @@ const CurrentCharity = ({ charity }: CurrentCharityProps) => {
       <img
         src={charity.imageUrl}
         alt={charity.name}
-        style={{ width: "300px", height: "300px" }}
+        style={{ maxWidth: "300px" }}
       />
       <Box
         component={Paper}

--- a/apps/frontend/src/components/CurrentCharity.tsx
+++ b/apps/frontend/src/components/CurrentCharity.tsx
@@ -63,6 +63,11 @@ const CurrentCharity = ({ charity }: CurrentCharityProps) => {
       >
         {charity.description}
       </Typography>
+      <img
+        src={charity.imageUrl}
+        alt={charity.name}
+        style={{ width: "300px", height: "300px" }}
+      />
       <Box
         component={Paper}
         elevation={2}


### PR DESCRIPTION
# Description
I forgot to show the image associated with the charity 🫣 


<img width="1470" alt="Screenshot 2024-07-16 at 1 18 23 PM" src="https://github.com/user-attachments/assets/09bfa5c1-c48a-4e01-9966-04d7ae38d329">


Closes #298 

## How to Test


## Checklist
- [ ] The code includes tests if relevant
- [ ] I have *actually* self-reviewed my changes and done QA
