### PR TITLE
[Search] Speed up by 6x with permanent connection pool

### DIFF
--- a/apps/algorithm/search/src/database.py
+++ b/apps/algorithm/search/src/database.py
@@ -1,5 +1,4 @@
 import asyncpg
-from fastapi import HTTPException
 
 from .config import DB_ENDPOINT
 from opentelemetry.instrumentation.asyncpg import AsyncPGInstrumentor
@@ -8,10 +7,12 @@ AsyncPGInstrumentor().instrument()
 
 DB_POOL = None
 
+
 async def initialize_db():
     global DB_POOL
     if not DB_POOL:
         DB_POOL = await asyncpg.create_pool(dsn=DB_ENDPOINT)
+
 
 async def insert_user_search(user_id: int, search_term: str):
     await initialize_db()


### PR DESCRIPTION
# Description
The search service is currently creating a new database connection for *every* request. This. is. slow. So......very.....sloooooooow.

Implemented a database connection pool and now response times are 6x faster (~120ms -> ~18ms)

Closes #424

## How to Test
| Before|After|
|---|---|
| ![image](https://github.com/user-attachments/assets/b6a782ad-cd1f-4b60-93ed-21e530aadc42)|![image](https://github.com/user-attachments/assets/82e6fb0f-0ecd-4b7f-bd90-c09568fedaca)|

## Checklist
- [ ] The code includes tests if relevant
- [x] I have *actually* self-reviewed my changes and done QA
