### PR TITLE
No more recommender in actions testing workflow

### DIFF
--- a/.github/workflows/algorithm.yml
+++ b/.github/workflows/algorithm.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        service: [search, recommend]
+        service: [search]
       fail-fast: false
     defaults:
       run:


### PR DESCRIPTION
# Description

The recommender is not feasible to test on Actions due to the massive model it needs to download. Perhaps in the future we can implement some caching or something, but right now the recommender tests are flaky and failing at times. 
