### PR TITLE
Gavin/348 update search endpoint to return charity status

### DIFF
--- a/apps/algorithm/search/src/routes.py
+++ b/apps/algorithm/search/src/routes.py
@@ -122,7 +122,9 @@ async def search(
             "description": hit["_source"]["description"],
             "price": hit["_source"]["price"],
             "dateCreated": hit["_source"]["dateCreated"],
-            "charityID": str(hit["_source"]["charityId"]) if hit["_source"]["charityId"] else None,
+            "charityID": str(hit["_source"]["charityId"])
+            if hit["_source"]["charityId"]
+            else None,
             "imageUrl": hit["_source"]["image_urls"][0]
             if hit["_source"]["image_urls"]
             else None,

--- a/apps/algorithm/search/src/routes.py
+++ b/apps/algorithm/search/src/routes.py
@@ -122,8 +122,8 @@ async def search(
             "description": hit["_source"]["description"],
             "price": hit["_source"]["price"],
             "dateCreated": hit["_source"]["dateCreated"],
-            "imageUrl": hit["_source"]["image_urls"][0],
-            "charityID": str(hit["_source"]["charityId"])
+            "charityID": str(hit["_source"]["charityId"]) if hit["_source"]["charityId"] else None,
+            "imageUrl": hit["_source"]["image_urls"][0]
             if hit["_source"]["image_urls"]
             else None,
         }

--- a/apps/algorithm/search/src/routes.py
+++ b/apps/algorithm/search/src/routes.py
@@ -122,7 +122,8 @@ async def search(
             "description": hit["_source"]["description"],
             "price": hit["_source"]["price"],
             "dateCreated": hit["_source"]["dateCreated"],
-            "imageUrl": hit["_source"]["image_urls"][0]
+            "imageUrl": hit["_source"]["image_urls"][0],
+            "charityID": str(hit["_source"]["charityId"])
             if hit["_source"]["image_urls"]
             else None,
         }

--- a/apps/algorithm/search/src/test_server.py
+++ b/apps/algorithm/search/src/test_server.py
@@ -79,6 +79,7 @@ def test_search_for_existing_listing(auth_headers, mock_insert_user_search):
             "dateCreated": "2024-05-22T10:30:00Z",
             "image_urls": ["https://example.com/image1.jpg"],
             "users": {"name": "billybobjoe"},
+            "charityId": None,  # Example with charityId as None
         },
     )
     es.indices.refresh(index=TEST_INDEX)
@@ -103,6 +104,7 @@ def test_search_for_existing_listing(auth_headers, mock_insert_user_search):
                 "price": 450,
                 "dateCreated": "2024-05-22T10:30:00Z",
                 "imageUrl": "https://example.com/image1.jpg",
+                "charityID": None,
             }
         ],
         "totalItems": 1,
@@ -125,6 +127,7 @@ def test_search_for_multiple_listings(auth_headers, mock_insert_user_search):
             "dateCreated": "2024-05-22T10:30:00Z",
             "image_urls": ["https://example.com/image1.jpg"],
             "users": {"name": "billybobjoe"},
+            "charityId": "12345",  # Example with charityId as a string
         },
     )
     es.index(
@@ -141,6 +144,7 @@ def test_search_for_multiple_listings(auth_headers, mock_insert_user_search):
             "dateCreated": "2024-06-01T12:00:00Z",
             "image_urls": ["https://example.com/image2.jpg"],
             "users": {"name": "janedoe"},
+            "charityId": None,
         },
     )
     es.indices.refresh(index=TEST_INDEX)
@@ -165,6 +169,7 @@ def test_search_for_multiple_listings(auth_headers, mock_insert_user_search):
                 "price": 200.0,
                 "dateCreated": "2024-06-01T12:00:00Z",
                 "imageUrl": "https://example.com/image2.jpg",
+                "charityID": None,
             },
             {
                 "listingID": "abc123",
@@ -175,6 +180,7 @@ def test_search_for_multiple_listings(auth_headers, mock_insert_user_search):
                 "price": 450.0,
                 "dateCreated": "2024-05-22T10:30:00Z",
                 "imageUrl": "https://example.com/image1.jpg",
+                "charityID": "12345",
             },
         ],
         "totalItems": 2,
@@ -227,6 +233,7 @@ def test_search_with_price_range(auth_headers, mock_insert_user_search):
             "dateCreated": "2024-05-22T10:30:00Z",
             "image_urls": ["https://example.com/image1.jpg"],
             "users": {"name": "billybobjoe"},
+            "charityId": "12345",
         },
     )
     es.indices.refresh(index=TEST_INDEX)
@@ -253,6 +260,7 @@ def test_search_with_price_range(auth_headers, mock_insert_user_search):
                 "price": 450.0,
                 "dateCreated": "2024-05-22T10:30:00Z",
                 "imageUrl": "https://example.com/image1.jpg",
+                "charityID": "12345",
             }
         ],
         "totalItems": 1,
@@ -275,6 +283,7 @@ def test_search_with_too_low_price_range_fail(auth_headers, mock_insert_user_sea
             "dateCreated": "2024-05-22T10:30:00Z",
             "image_urls": ["https://example.com/image1.jpg"],
             "users": {"name": "billybobjoe"},
+            "charityId": "12345",
         },
     )
     es.indices.refresh(index=TEST_INDEX)
@@ -309,6 +318,7 @@ def test_search_with_too_high_price_range_fail(auth_headers, mock_insert_user_se
             "dateCreated": "2024-05-22T10:30:00Z",
             "image_urls": ["https://example.com/image1.jpg"],
             "users": {"name": "billybobjoe"},
+            "charityId": "12345",
         },
     )
     es.indices.refresh(index=TEST_INDEX)
@@ -394,6 +404,7 @@ def test_search_with_status(auth_headers, mock_insert_user_search):
             "dateCreated": "2024-05-22T10:30:00Z",
             "image_urls": ["https://example.com/image1.jpg"],
             "users": {"name": "billybobjoe"},
+            "charityId": "12345",
         },
     )
     es.index(
@@ -410,6 +421,7 @@ def test_search_with_status(auth_headers, mock_insert_user_search):
             "dateCreated": "2024-06-01T12:00:00Z",
             "image_urls": ["https://example.com/image2.jpg"],
             "users": {"name": "janedoe"},
+            "charityId": None,
         },
     )
     es.indices.refresh(index=TEST_INDEX)
@@ -435,6 +447,7 @@ def test_search_with_status(auth_headers, mock_insert_user_search):
                 "price": 450.0,
                 "dateCreated": "2024-05-22T10:30:00Z",
                 "imageUrl": "https://example.com/image1.jpg",
+                "charityID": "12345",
             }
         ],
         "totalItems": 1,
@@ -457,6 +470,7 @@ def test_search_with_status_sold(auth_headers, mock_insert_user_search):
             "dateCreated": "2024-05-22T10:30:00Z",
             "image_urls": ["https://example.com/image1.jpg"],
             "users": {"name": "billybobjoe"},
+            "charityId": "12345",
         },
     )
     es.index(
@@ -473,6 +487,7 @@ def test_search_with_status_sold(auth_headers, mock_insert_user_search):
             "dateCreated": "2024-06-01T12:00:00Z",
             "image_urls": ["https://example.com/image2.jpg"],
             "users": {"name": "janedoe"},
+            "charityId": None,
         },
     )
     es.indices.refresh(index=TEST_INDEX)
@@ -498,6 +513,7 @@ def test_search_with_status_sold(auth_headers, mock_insert_user_search):
                 "price": 200.0,
                 "dateCreated": "2024-06-01T12:00:00Z",
                 "imageUrl": "https://example.com/image2.jpg",
+                "charityID": None,
             }
         ],
         "totalItems": 1,
@@ -546,6 +562,7 @@ def test_search_with_user_search(auth_headers, mock_insert_user_search):
             "dateCreated": "2024-05-22T10:30:00Z",
             "image_urls": ["https://example.com/image1.jpg"],
             "users": {"name": "billybobjoe"},
+            "charityId": None,
         },
     )
     es.index(
@@ -557,11 +574,12 @@ def test_search_with_user_search(auth_headers, mock_insert_user_search):
             "title": "Used Laptop",
             "description": "Lightly used laptop for sale.",
             "price": 200.00,
-            "location": {"lat": 40.7128, "lon": -74.0060},
+            "location": {"lat": 45.4215, "lon": -75.6972},
             "status": "SOLD",
             "dateCreated": "2024-06-01T12:00:00Z",
             "image_urls": ["https://example.com/image2.jpg"],
             "users": {"name": "janedoe"},
+            "charityId": None,
         },
     )
     es.indices.refresh(index=TEST_INDEX)
@@ -587,6 +605,7 @@ def test_search_with_user_search(auth_headers, mock_insert_user_search):
                 "price": 450.0,
                 "dateCreated": "2024-05-22T10:30:00Z",
                 "imageUrl": "https://example.com/image1.jpg",
+                "charityID": None,
             }
         ],
         "totalItems": 1,
@@ -609,6 +628,7 @@ def test_search_with_user_search_negative(auth_headers, mock_insert_user_search)
             "dateCreated": "2024-05-22T10:30:00Z",
             "image_urls": ["https://example.com/image1.jpg"],
             "users": {"name": "billybobjoe"},
+            "charityId": "12345",
         },
     )
     es.index(
@@ -625,6 +645,7 @@ def test_search_with_user_search_negative(auth_headers, mock_insert_user_search)
             "dateCreated": "2024-06-01T12:00:00Z",
             "image_urls": ["https://example.com/image2.jpg"],
             "users": {"name": "janedoe"},
+            "charityId": None,
         },
     )
     es.indices.refresh(index=TEST_INDEX)
@@ -686,6 +707,7 @@ def test_only_return_results_within_5km_of_location(
             "dateCreated": "2024-05-22T10:30:00Z",
             "image_urls": ["https://example.com/image1.jpg"],
             "users": {"name": "billybobjoe"},
+            "charityId": "12345",
         },
     )
     es.index(
@@ -702,6 +724,7 @@ def test_only_return_results_within_5km_of_location(
             "dateCreated": "2024-06-01T12:00:00Z",
             "image_urls": ["https://example.com/image2.jpg"],
             "users": {"name": "janedoe"},
+            "charityId": None,
         },
     )
     es.indices.refresh(index=TEST_INDEX)
@@ -726,6 +749,7 @@ def test_only_return_results_within_5km_of_location(
                 "price": 450.00,
                 "dateCreated": "2024-05-22T10:30:00Z",
                 "imageUrl": "https://example.com/image1.jpg",
+                "charityID": "12345",
             }
         ],
         "totalItems": 1,
@@ -824,6 +848,7 @@ def test_search_with_sorting_by_relevance(auth_headers, mock_insert_user_search)
             "dateCreated": "2024-06-01T12:00:00Z",
             "image_urls": ["https://example.com/image3.jpg"],
             "users": {"name": "wally monga"},
+            "charityId": "12345",
         },
     )
     es.index(
@@ -840,6 +865,7 @@ def test_search_with_sorting_by_relevance(auth_headers, mock_insert_user_search)
             "dateCreated": "2024-05-22T10:30:00Z",
             "image_urls": ["https://example.com/image1.jpg"],
             "users": {"name": "billybobjoe"},
+            "charityId": None,
         },
     )
     es.index(
@@ -856,6 +882,7 @@ def test_search_with_sorting_by_relevance(auth_headers, mock_insert_user_search)
             "dateCreated": "2024-06-01T12:00:00Z",
             "image_urls": ["https://example.com/image2.jpg"],
             "users": {"name": "janedoe"},
+            "charityId": "54321",
         },
     )
     es.indices.refresh(index=TEST_INDEX)
@@ -896,6 +923,7 @@ def test_search_with_sorting_by_price_asc(auth_headers, mock_insert_user_search)
             "dateCreated": "2024-05-22T10:30:00Z",
             "image_urls": ["https://example.com/image1.jpg"],
             "users": {"name": "billybobjoe"},
+            "charityId": "12345",
         },
     )
     es.index(
@@ -912,6 +940,7 @@ def test_search_with_sorting_by_price_asc(auth_headers, mock_insert_user_search)
             "dateCreated": "2024-06-01T12:00:00Z",
             "image_urls": ["https://example.com/image2.jpg"],
             "users": {"name": "janedoe"},
+            "charityId": None,
         },
     )
     es.indices.refresh(index=TEST_INDEX)
@@ -951,6 +980,7 @@ def test_search_with_sorting_by_price_desc(auth_headers, mock_insert_user_search
             "dateCreated": "2024-05-22T10:30:00Z",
             "image_urls": ["https://example.com/image1.jpg"],
             "users": {"name": "billybobjoe"},
+            "charityId": "12345",
         },
     )
     es.index(
@@ -967,6 +997,7 @@ def test_search_with_sorting_by_price_desc(auth_headers, mock_insert_user_search
             "dateCreated": "2024-06-01T12:00:00Z",
             "image_urls": ["https://example.com/image2.jpg"],
             "users": {"name": "janedoe"},
+            "charityId": None,
         },
     )
     es.indices.refresh(index=TEST_INDEX)
@@ -1006,6 +1037,7 @@ def test_search_with_sorting_by_listed_time_asc(auth_headers, mock_insert_user_s
             "dateCreated": "2024-05-22T10:30:00Z",
             "image_urls": ["https://example.com/image1.jpg"],
             "users": {"name": "billybobjoe"},
+            "charityId": "12345",
         },
     )
     es.index(
@@ -1022,6 +1054,7 @@ def test_search_with_sorting_by_listed_time_asc(auth_headers, mock_insert_user_s
             "dateCreated": "2024-06-01T12:00:00Z",
             "image_urls": ["https://example.com/image2.jpg"],
             "users": {"name": "janedoe"},
+            "charityId": None,
         },
     )
     es.indices.refresh(index=TEST_INDEX)
@@ -1062,6 +1095,7 @@ def test_search_with_sorting_by_listed_time_desc(auth_headers, mock_insert_user_
             "dateCreated": "2024-05-22T10:30:00Z",
             "image_urls": ["https://example.com/image1.jpg"],
             "users": {"name": "billybobjoe"},
+            "charityId": "12345",
         },
     )
     es.index(
@@ -1078,6 +1112,7 @@ def test_search_with_sorting_by_listed_time_desc(auth_headers, mock_insert_user_
             "dateCreated": "2024-06-01T12:00:00Z",
             "image_urls": ["https://example.com/image2.jpg"],
             "users": {"name": "janedoe"},
+            "charityId": None,
         },
     )
     es.indices.refresh(index=TEST_INDEX)
@@ -1118,6 +1153,7 @@ def test_search_with_sorting_by_distance_asc(auth_headers, mock_insert_user_sear
             "dateCreated": "2024-05-22T10:30:00Z",
             "image_urls": ["https://example.com/image1.jpg"],
             "users": {"name": "billybobjoe"},
+            "charityId": "12345",
         },
     )
     es.index(
@@ -1134,6 +1170,7 @@ def test_search_with_sorting_by_distance_asc(auth_headers, mock_insert_user_sear
             "dateCreated": "2024-06-01T12:00:00Z",
             "image_urls": ["https://example.com/image2.jpg"],
             "users": {"name": "janedoe"},
+            "charityId": None,
         },
     )
     es.indices.refresh(index=TEST_INDEX)
@@ -1174,6 +1211,7 @@ def test_search_with_sorting_by_distance_desc(auth_headers, mock_insert_user_sea
             "dateCreated": "2024-05-22T10:30:00Z",
             "image_urls": ["https://example.com/image1.jpg"],
             "users": {"name": "billybobjoe"},
+            "charityId": "12345",
         },
     )
     es.index(
@@ -1190,6 +1228,7 @@ def test_search_with_sorting_by_distance_desc(auth_headers, mock_insert_user_sea
             "dateCreated": "2024-06-01T12:00:00Z",
             "image_urls": ["https://example.com/image2.jpg"],
             "users": {"name": "janedoe"},
+            "charityId": None,
         },
     )
     es.indices.refresh(index=TEST_INDEX)
@@ -1259,6 +1298,7 @@ def test_search_with_pagination(auth_headers, mock_insert_user_search):
             "dateCreated": f"2024-06-{i + 1:02d}T12:00:00Z",
             "image_urls": [f"https://example.com/image{i}.jpg"],
             "users": {"name": f"seller_name{i}"},
+            "charityId": None if i % 2 == 0 else str(i),
         }
         for i in range(15)
     ]
@@ -1354,6 +1394,7 @@ def test_search_with_missing_pagination_parameters(
             "dateCreated": f"2024-06-{i + 1:02d}T12:00:00Z",
             "image_urls": [f"https://example.com/image{i}.jpg"],
             "users": {"name": f"seller_name{i}"},
+            "charityId": None if i % 2 == 0 else str(i),
         }
         for i in range(21)
     ]
@@ -1468,6 +1509,7 @@ def test_total_items_count_with_multiple_listings(
             "dateCreated": f"2024-06-{i + 1:02d}T12:00:00Z",
             "image_urls": [f"https://example.com/image{i}.jpg"],
             "users": {"name": f"seller_name{i}"},
+            "charityId": None if i % 2 == 0 else str(i),
         }
         for i in range(10)
     ]
@@ -1512,6 +1554,7 @@ def test_total_items_count_with_filter(auth_headers, mock_insert_user_search):
             "dateCreated": f"2024-06-{i + 1:02d}T12:00:00Z",
             "image_urls": [f"https://example.com/image{i}.jpg"],
             "users": {"name": f"seller_name{i}"},
+            "charityId": None if i % 2 == 0 else str(i),
         }
         for i in range(20)
     ]
@@ -1558,6 +1601,7 @@ def test_fuzzy_search(auth_headers, mock_insert_user_search):
             "dateCreated": "2024-05-22T10:30:00Z",
             "image_urls": ["https://example.com/image1.jpg"],
             "users": {"name": "billybobjoe"},
+            "charityId": None,
         },
     )
     es.indices.refresh(index=TEST_INDEX)
@@ -1582,6 +1626,7 @@ def test_fuzzy_search(auth_headers, mock_insert_user_search):
                 "price": 8.00,
                 "dateCreated": "2024-05-22T10:30:00Z",
                 "imageUrl": "https://example.com/image1.jpg",
+                "charityID": None,
             }
         ],
         "totalItems": 1,

--- a/apps/data/pgsync/schema.json
+++ b/apps/data/pgsync/schema.json
@@ -13,7 +13,8 @@
                 "description",
                 "image_urls",
                 "created_at",
-                "location"
+                "location",
+                "charity_id"
             ],
             "children": [
                 {
@@ -42,7 +43,8 @@
                 {
                     "listing_id": "listingId",
                     "seller_id": "sellerId",
-                    "created_at": "dateCreated"
+                    "created_at": "dateCreated",
+                    "charity_id": "charityId"
                 },
                 "mapping":
                 {

--- a/apps/frontend/src/components/listingCard.tsx
+++ b/apps/frontend/src/components/listingCard.tsx
@@ -227,7 +227,7 @@ ListingCard.propTypes = {
     price: PropTypes.number.isRequired,
     dateCreated: PropTypes.string.isRequired,
     imageUrl: PropTypes.string.isRequired,
-    charityId: PropTypes.string.isRequired,
+    charityID: PropTypes.string.isRequired,
   }).isRequired,
 };
 

--- a/apps/frontend/src/components/listingCard.tsx
+++ b/apps/frontend/src/components/listingCard.tsx
@@ -16,7 +16,7 @@ export interface ListingObject {
   price: number;
   dateCreated: string;
   imageUrl: string;
-  charityId: string;
+  charityID?: string;
 }
 
 interface ListingCardProps {
@@ -95,7 +95,7 @@ const ListingCard = ({
       onClick={handleListingClick}
     >
       <div style={{ position: "relative", width: "100%", maxHeight: "40vh" }}>
-        {listing.charityId != null && (
+        {listing.charityID != null && (
           <img
             src={CharityBanner}
             alt="charityBanner"


### PR DESCRIPTION
# Description
Updated the search endpoint to return the CharityID field in accordance with the API contract:
![image](https://github.com/user-attachments/assets/5def676c-f86c-4764-bdd8-06c9a0edae56)

On the frontend it looks like this. Nice job Chloe!
![image](https://github.com/user-attachments/assets/e872f233-e775-4787-87e9-8b372d3c7c96)

Most of the changes are updating test_server.py to use the new charity endpoint.

There are a few frontend changes which are as follows:
- Changing charityId to CharityID to comply with the search and recommender endpoints
- Making CharityID nullable (since null is used to check whether an item is NOT for charity)

There is still this issue on the frontend, which I suspect is because the recommender does not yet have returned charityID values. If someone knows its for a different reason please let me know and I'll change it promptly:
![image](https://github.com/user-attachments/assets/82f9af8a-4071-404a-9949-5004cd0ba99f)


Closes #348

## How to Test
* Build the application
* Create an account/login
* Search for some stuff (**some** items in search should be labeled as for charity like so):
![image](https://github.com/user-attachments/assets/8a1e11af-9390-4484-9c28-d31fef3c8c4a)

* Once the app is built, run these two commands in a separate terminal: `docker exec -it martletplace_search bash` then `pytest src/test_server.py`


## Checklist
- [X] The code includes tests if relevant
- [X] I have *actually* self-reviewed my changes and done QA
