### PR TITLE
Brent/backend fixing listing endpoints charities

### DIFF
--- a/apps/backend/listing/src/createListing.ts
+++ b/apps/backend/listing/src/createListing.ts
@@ -16,7 +16,8 @@ const createListing = async (
     return res.status(400).json({ error: "missing parameter in request" });
   }
 
-  const { title, description, price, location, images, markedForCharity} = listing;
+  const { title, description, price, location, images, markedForCharity } =
+    listing;
 
   if (
     !title ||
@@ -36,8 +37,7 @@ const createListing = async (
 
   try {
     let charity_id: number | null = null;
-    if (markedForCharity){
-      
+    if (markedForCharity) {
       const currentCharity = await db.oneOrNone(
         `SELECT c.charity_id AS id, c.name, c.description, c.start_date AS "startDate", c.end_date AS "endDate", c.image_url AS "imageUrl", 
           jsonb_agg(jsonb_build_object('name', o.name, 'logoUrl', o.logo_url, 'donated', o.donated, 'receiving', o.receiving)) AS organizations
@@ -91,7 +91,7 @@ const createListing = async (
       dateModified: createdListing.modified_at,
       reviews: [],
       images: createdListing.image_urls.map((url: string) => ({ url })),
-      charityId: charity_id
+      charityId: charity_id,
     };
 
     return res.status(201).json({ listing: responseListing });

--- a/apps/backend/listing/src/createListing.ts
+++ b/apps/backend/listing/src/createListing.ts
@@ -16,7 +16,7 @@ const createListing = async (
     return res.status(400).json({ error: "missing parameter in request" });
   }
 
-  const { title, description, price, location, images } = listing;
+  const { title, description, price, location, images, markedForCharity} = listing;
 
   if (
     !title ||
@@ -25,7 +25,8 @@ const createListing = async (
     !location ||
     !images ||
     !location.latitude ||
-    !location.longitude
+    !location.longitude ||
+    typeof markedForCharity !== "boolean"
   ) {
     console.error("missing parameter in request");
     return res.status(400).json({ error: "missing parameter in request" });
@@ -34,10 +35,29 @@ const createListing = async (
   const formattedLocation = `(${location.latitude},${location.longitude})`;
 
   try {
+    let charity_id: number | null = null;
+    if (markedForCharity){
+      
+      const currentCharity = await db.oneOrNone(
+        `SELECT c.charity_id AS id, c.name, c.description, c.start_date AS "startDate", c.end_date AS "endDate", c.image_url AS "imageUrl", 
+          jsonb_agg(jsonb_build_object('name', o.name, 'logoUrl', o.logo_url, 'donated', o.donated, 'receiving', o.receiving)) AS organizations
+        FROM charities c
+        LEFT JOIN organizations o ON c.charity_id = o.charity_id
+        WHERE NOW() BETWEEN c.start_date AND c.end_date
+        GROUP BY c.charity_id
+        ORDER BY c.start_date DESC
+        LIMIT 1
+        `,
+      );
+
+      if (currentCharity) {
+        charity_id = currentCharity.charity_id;
+      }
+    }
     const createdListing = await db.one(
-      `INSERT INTO listings (title, description, price, location, image_urls, status, created_at, modified_at, seller_id)
-       VALUES ($1, $2, $3, $4, $5, 'AVAILABLE', NOW(), NOW(), $6)
-       RETURNING listing_id, title, price, location, status, description, image_urls, created_at, modified_at;`,
+      `INSERT INTO listings (title, description, price, location, image_urls, status, created_at, modified_at, seller_id, charity_id)
+       VALUES ($1, $2, $3, $4, $5, 'AVAILABLE', NOW(), NOW(), $6, $7)
+       RETURNING listing_id, title, price, location, status, description, image_urls, created_at, modified_at, charity_id`,
       [
         title,
         description,
@@ -45,6 +65,7 @@ const createListing = async (
         formattedLocation,
         images.map((image: { url: string }) => image.url),
         userID,
+        charity_id,
       ],
     );
 
@@ -70,6 +91,7 @@ const createListing = async (
       dateModified: createdListing.modified_at,
       reviews: [],
       images: createdListing.image_urls.map((url: string) => ({ url })),
+      charityId: charity_id
     };
 
     return res.status(201).json({ listing: responseListing });

--- a/apps/backend/listing/src/getListingById.ts
+++ b/apps/backend/listing/src/getListingById.ts
@@ -41,7 +41,7 @@ const getListingById = async (
         l.created_at AS "dateCreated",
         l.modified_at AS "dateModified",
         l.image_urls,
-        l.charity_id
+        l.charity_id AS "charityId"
       FROM 
         listings l
       JOIN 

--- a/apps/backend/listing/src/getListingById.ts
+++ b/apps/backend/listing/src/getListingById.ts
@@ -40,7 +40,8 @@ const getListingById = async (
         l.status,
         l.created_at AS "dateCreated",
         l.modified_at AS "dateModified",
-        l.image_urls
+        l.image_urls,
+        l.charity_id
       FROM 
         listings l
       JOIN 

--- a/apps/backend/listing/src/updateListing.ts
+++ b/apps/backend/listing/src/updateListing.ts
@@ -16,7 +16,8 @@ const updateListing = async (
     return res.status(400).json({ error: "missing parameter in request" });
   }
 
-  const { title, description, price, location, images, markedForCharity } = listing;
+  const { title, description, price, location, images, markedForCharity } =
+    listing;
 
   if (
     !title ||
@@ -25,7 +26,7 @@ const updateListing = async (
     !location ||
     !images ||
     !location.latitude ||
-    !location.longitude || 
+    !location.longitude ||
     typeof markedForCharity !== "boolean"
   ) {
     console.error("missing parameter in request");
@@ -35,10 +36,8 @@ const updateListing = async (
   const formattedLocation = `(${location.latitude},${location.longitude})`;
 
   try {
-
     let charity_id: number | null = null;
-    if (markedForCharity){
-      
+    if (markedForCharity) {
       const currentCharity = await db.oneOrNone(
         `SELECT c.charity_id AS id, c.name, c.description, c.start_date AS "startDate", c.end_date AS "endDate", c.image_url AS "imageUrl", 
           jsonb_agg(jsonb_build_object('name', o.name, 'logoUrl', o.logo_url, 'donated', o.donated, 'receiving', o.receiving)) AS organizations

--- a/apps/backend/listing/src/updateListing.ts
+++ b/apps/backend/listing/src/updateListing.ts
@@ -16,7 +16,7 @@ const updateListing = async (
     return res.status(400).json({ error: "missing parameter in request" });
   }
 
-  const { title, description, price, location, images } = listing;
+  const { title, description, price, location, images, markedForCharity } = listing;
 
   if (
     !title ||
@@ -25,7 +25,8 @@ const updateListing = async (
     !location ||
     !images ||
     !location.latitude ||
-    !location.longitude
+    !location.longitude || 
+    typeof markedForCharity !== "boolean"
   ) {
     console.error("missing parameter in request");
     return res.status(400).json({ error: "missing parameter in request" });
@@ -34,6 +35,27 @@ const updateListing = async (
   const formattedLocation = `(${location.latitude},${location.longitude})`;
 
   try {
+
+    let charity_id: number | null = null;
+    if (markedForCharity){
+      
+      const currentCharity = await db.oneOrNone(
+        `SELECT c.charity_id AS id, c.name, c.description, c.start_date AS "startDate", c.end_date AS "endDate", c.image_url AS "imageUrl", 
+          jsonb_agg(jsonb_build_object('name', o.name, 'logoUrl', o.logo_url, 'donated', o.donated, 'receiving', o.receiving)) AS organizations
+        FROM charities c
+        LEFT JOIN organizations o ON c.charity_id = o.charity_id
+        WHERE NOW() BETWEEN c.start_date AND c.end_date
+        GROUP BY c.charity_id
+        ORDER BY c.start_date DESC
+        LIMIT 1
+        `,
+      );
+
+      if (currentCharity) {
+        charity_id = currentCharity.charity_id;
+      }
+    }
+
     const updatedListing = await db.oneOrNone(
       `UPDATE listings
        SET title = $1,
@@ -41,9 +63,10 @@ const updateListing = async (
            price = $3,
            location = $4,
            image_urls = $5,
-           status = $6
+           status = $6,
+           charity_id = $8
        WHERE listing_id = $7
-       RETURNING listing_id, seller_id, buyer_id, title, price, location, status, description, image_urls, created_at, modified_at;`,
+       RETURNING listing_id, seller_id, buyer_id, title, price, location, status, description, image_urls, created_at, modified_at, charity_id;`,
       [
         title,
         description,
@@ -52,6 +75,7 @@ const updateListing = async (
         images.map((image: { url: string }) => image.url),
         status,
         id,
+        charity_id,
       ],
     );
 
@@ -73,6 +97,7 @@ const updateListing = async (
       dateCreated: updatedListing.created_at,
       dateModified: updatedListing.modified_at,
       images: updatedListing.image_urls.map((url: string) => ({ url })),
+      charityId: charity_id,
     };
 
     return res.status(200).json(responseListing);

--- a/apps/backend/listing/tests/createListing.test.ts
+++ b/apps/backend/listing/tests/createListing.test.ts
@@ -20,6 +20,7 @@ describe('Create Listing Endpoint', () => {
             { url: 'https://example.com/image1.png' },
             { url: 'https://example.com/image2.png' },
           ],
+          markedForCharity: false,
         },
       },
       user: { userId: 1 },
@@ -85,6 +86,7 @@ describe('Create Listing Endpoint', () => {
           { url: 'https://example.com/image1.png' },
           { url: 'https://example.com/image2.png' },
         ],
+        charityId: null,
       },
     });
   });
@@ -97,6 +99,7 @@ describe('Create Listing Endpoint', () => {
           description: 'This is a sample listing description',
           price: 100,
           location: {},
+          markedForCharity: false,
         },
       },
       user: { userId: 1 },

--- a/apps/backend/listing/tests/getListingByID.test.ts
+++ b/apps/backend/listing/tests/getListingByID.test.ts
@@ -38,6 +38,7 @@ describe('Get Listing by ID Endpoint', () => {
             'https://example.com/image1.png',
             'https://example.com/image2.png',
           ],
+          charity_id: 1,
         })),
       any: vi.fn().mockResolvedValue([{
         listing_review_id: 1,
@@ -90,6 +91,7 @@ describe('Get Listing by ID Endpoint', () => {
         { url: 'https://example.com/image2.png' },
       ],
       distance: 0,
+      charityId: 1,
     });
   });
 

--- a/apps/backend/listing/tests/getListingByID.test.ts
+++ b/apps/backend/listing/tests/getListingByID.test.ts
@@ -32,13 +32,13 @@ describe('Get Listing by ID Endpoint', () => {
           price: 100,
           location: '48.4284,-123.3656',
           status: 'AVAILABLE',
-          dateCreated: new Date(),
-          dateModified: new Date(),
+          dateCreated: '2024-07-30T18:17:02.944Z',
+          dateModified: '2024-07-30T18:17:02.944Z',
           image_urls: [
             'https://example.com/image1.png',
             'https://example.com/image2.png',
           ],
-          charity_id: 1,
+          charityId: 1,
         })),
       any: vi.fn().mockResolvedValue([{
         listing_review_id: 1,
@@ -47,8 +47,8 @@ describe('Get Listing by ID Endpoint', () => {
         comment: 'Great listing!',
         userID: 2,
         listingID: 1,
-        dateCreated: new Date(),
-        dateModified: new Date(),
+        dateCreated: '2024-07-30T18:17:02.944Z',
+        dateModified: '2024-07-30T18:17:02.944Z',
       }]),
     } as unknown as IDatabase<object>;
 
@@ -72,8 +72,8 @@ describe('Get Listing by ID Endpoint', () => {
         longitude: -123.3656,
       },
       status: 'AVAILABLE',
-      dateCreated: expect.any(Date),
-      dateModified: expect.any(Date),
+      dateCreated: '2024-07-30T18:17:02.944Z',
+      dateModified: '2024-07-30T18:17:02.944Z',
       reviews: [
         {
           listing_review_id: 1,
@@ -82,8 +82,8 @@ describe('Get Listing by ID Endpoint', () => {
           comment: 'Great listing!',
           userID: 2,
           listingID: 1,
-          dateCreated: expect.any(Date),
-          dateModified: expect.any(Date),
+          dateCreated: '2024-07-30T18:17:02.944Z',
+          dateModified: '2024-07-30T18:17:02.944Z',
         },
       ],
       images: [

--- a/apps/backend/listing/tests/updateListing.test.ts
+++ b/apps/backend/listing/tests/updateListing.test.ts
@@ -20,6 +20,7 @@ describe('Update Listing Endpoint', () => {
             { url: 'https://example.com/image1.png' },
             { url: 'https://example.com/image2.png' },
           ],
+          markedForCharity: false,
         },
         status: 'AVAILABLE',
       },
@@ -42,8 +43,9 @@ describe('Update Listing Endpoint', () => {
           'https://example.com/image2.png',
         ],
         status: 'AVAILABLE',
-        created_at: new Date(),
-        modified_at: new Date(),
+        created_at: '2024-07-30T18:17:02.944Z',
+        modified_at: '2024-07-30T18:17:02.944Z',
+        charity_id: null,
       }),
     } as unknown as IDatabase<object>;
 
@@ -60,12 +62,13 @@ describe('Update Listing Endpoint', () => {
         longitude: -74.0060,
       },
       status: 'AVAILABLE',
-      dateCreated: expect.any(Date),
-      dateModified: expect.any(Date),
+      dateCreated: '2024-07-30T18:17:02.944Z',
+      dateModified: '2024-07-30T18:17:02.944Z',
       images: [
         { url: 'https://example.com/image1.png' },
         { url: 'https://example.com/image2.png' },
       ],
+      charityId: null,
     });
   });
 
@@ -85,6 +88,7 @@ describe('Update Listing Endpoint', () => {
             { url: 'https://example.com/image1.png' },
             { url: 'https://example.com/image2.png' },
           ],
+          markedForCharity: false,
         },
         status: 'AVAILABLE',
       },
@@ -103,5 +107,77 @@ describe('Update Listing Endpoint', () => {
 
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({ error: 'Listing not found' });
+  });
+
+  it('should update a listing with markedForCharity and fetch charity id', async () => {
+    const req = {
+      params: { id: '1' },
+      body: {
+        listing: {
+          title: 'Updated Listing Two',
+          description: 'Updated description for listing two',
+          price: 150,
+          location: {
+            latitude: 40.7128,
+            longitude: -74.0060,
+          },
+          images: [
+            { url: 'https://example.com/image1.png' },
+            { url: 'https://example.com/image2.png' },
+          ],
+          markedForCharity: true,
+        },
+        status: 'AVAILABLE',
+      },
+    } as unknown as Request;
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    } as unknown as Response;
+
+    const db = {
+      oneOrNone: vi.fn()
+        .mockResolvedValueOnce({
+          charity_id: 1,
+        })
+        .mockResolvedValueOnce({
+          listing_id: 1,
+          title: 'Updated Listing Two',
+          description: 'Updated description for listing two',
+          price: 150,
+          location: '40.7128,-74.0060',
+          image_urls: [
+            'https://example.com/image1.png',
+            'https://example.com/image2.png',
+          ],
+          status: 'AVAILABLE',
+          created_at: '2024-07-30T18:17:02.944Z',
+          modified_at: '2024-07-30T18:17:02.944Z',
+          charity_id: 1,
+        }),
+    } as unknown as IDatabase<object>;
+
+    await updateListing(req, res, db);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      listingID: 1,
+      title: 'Updated Listing Two',
+      description: 'Updated description for listing two',
+      price: 150,
+      location: {
+        latitude: 40.7128,
+        longitude: -74.0060,
+      },
+      status: 'AVAILABLE',
+      dateCreated: '2024-07-30T18:17:02.944Z',
+      dateModified: '2024-07-30T18:17:02.944Z',
+      images: [
+        { url: 'https://example.com/image1.png' },
+        { url: 'https://example.com/image2.png' },
+      ],
+      charityId: 1,
+    });
   });
 });


### PR DESCRIPTION
# Description
Get Listings needs the charity ID.
Post and Patch Listing needs to update the charityID and marked for charity.

Along with these changes to the fields, the GET, POST, and PATCH endpoints match the API spec. The main changes are the for POST and PATCH, if the markedForCharity boolean is set, we query the database to retrieve the current charity and attach the charity to the listing accordingly.

still todo:
Status of the charity drive, is not updated based on listings
Number of listings
Number of funds generated

Closes #535 

## How to Test
```npm test```

## Checklist
- [ ] The code includes tests if relevant
- [ ] I have *actually* self-reviewed my changes and done QA
