### PR TITLE
Fixed frontend console warning and removed inconsistent type checking

### DIFF
--- a/apps/frontend/src/components/listingCard.tsx
+++ b/apps/frontend/src/components/listingCard.tsx
@@ -1,5 +1,4 @@
 import { Grid, Button, Typography } from "@mui/material";
-import PropTypes from "prop-types";
 import { useNavigate } from "react-router-dom";
 import { useState } from "react";
 import _axios_instance from "../_axios_instance.tsx";
@@ -215,20 +214,6 @@ const ListingCard = ({
       </Grid>
     </Grid>
   );
-};
-
-ListingCard.propTypes = {
-  listing: PropTypes.shape({
-    listingID: PropTypes.string.isRequired,
-    sellerID: PropTypes.string.isRequired,
-    sellerName: PropTypes.string.isRequired,
-    title: PropTypes.string.isRequired,
-    description: PropTypes.string.isRequired,
-    price: PropTypes.number.isRequired,
-    dateCreated: PropTypes.string.isRequired,
-    imageUrl: PropTypes.string.isRequired,
-    charityID: PropTypes.string.isRequired,
-  }).isRequired,
 };
 
 export default ListingCard;


### PR DESCRIPTION
# Description
The propTypes stuff was almost definitely added by AI. We're not using that anywhere else in the project (we're using typescript to handle prop type checking instead)

The warning was because the propTypes was incorrectly marking charityID as a required field when it is nullable

Closes #543 