### PR TITLE
Insert to user_clicks only when user clicks on other user's listing.

### DIFF
--- a/apps/backend/listing/src/getListingById.ts
+++ b/apps/backend/listing/src/getListingById.ts
@@ -57,8 +57,7 @@ const getListingById = async (
       return res.status(200).json({ listing: {} });
     }
 
-    console.log("UserID: " + userID + "Seller ID: " + listing.seller_id);
-    if(userID !== listing.seller_id) {
+    if (userID !== listing.seller_id) {
       const insertClickQuery = `
         INSERT INTO user_clicks (user_id, listing_id, listing_title)
         VALUES ($1, $2, $3)

--- a/apps/backend/listing/src/getListingById.ts
+++ b/apps/backend/listing/src/getListingById.ts
@@ -41,7 +41,8 @@ const getListingById = async (
         l.created_at AS "dateCreated",
         l.modified_at AS "dateModified",
         l.image_urls,
-        l.charity_id AS "charityId"
+        l.charity_id AS "charityId",
+        l.seller_id
       FROM 
         listings l
       JOIN 
@@ -56,12 +57,15 @@ const getListingById = async (
       return res.status(200).json({ listing: {} });
     }
 
-    const insertClickQuery = `
-      INSERT INTO user_clicks (user_id, listing_id, listing_title)
-      VALUES ($1, $2, $3)
-    `;
+    console.log("UserID: " + userID + "Seller ID: " + listing.seller_id);
+    if(userID !== listing.seller_id) {
+      const insertClickQuery = `
+        INSERT INTO user_clicks (user_id, listing_id, listing_title)
+        VALUES ($1, $2, $3)
+      `;
 
-    await db.oneOrNone(insertClickQuery, [userID, id, listing.title]);
+      await db.oneOrNone(insertClickQuery, [userID, id, listing.title]);
+    }
 
     const reviewsQuery = `
       SELECT 


### PR DESCRIPTION
# Description
Currently when a user clicks on their own listing, click recommendations are altered based on that click. But this should not happen. 

Click  recommendations should only be tuned when a user clicks on another user's listing.

Closes #548 

## How to Test
From a fresh user, create a new listing and then click on it in "My Listings". 

Notice that your recommendations are unchanged.

## Checklist
- [ ] The code includes tests if relevant
- [ ] I have *actually* self-reviewed my changes and done QA
