### PR TITLE
Adds default images to algo endpoints

### DIFF
--- a/apps/frontend/src/components/listingCard.tsx
+++ b/apps/frontend/src/components/listingCard.tsx
@@ -123,7 +123,11 @@ const ListingCard = ({
           }}
         >
           <img
-            src={listing.imageUrl == "" ? imageDefault : listing.imageUrl}
+            src={
+              listing.imageUrl === "" || !listing.imageUrl
+                ? imageDefault
+                : listing.imageUrl
+            }
             alt={listing.title}
             style={{
               width: "100%",


### PR DESCRIPTION
# Description
Adds default image thumbnails to algo endpoint calls

![image](https://github.com/user-attachments/assets/ca50178a-89df-4a08-a9ef-a03e2f9b2335)


Closes #558

## How to Test
Run the application

## Checklist
- [ ] The code includes tests if relevant
- [ ] I have *actually* self-reviewed my changes and done QA
